### PR TITLE
Fixed compilation problems in QSDatabaseQueue

### DIFF
--- a/Classes/SQLite/QSDatabaseQueue.m
+++ b/Classes/SQLite/QSDatabaseQueue.m
@@ -9,6 +9,7 @@
 #import "FMDatabase.h"
 #import "FMDatabase+Extras.h"
 #import "QSDatabaseQueue.h"
+#import "QSPlatform.h"
 
 
 @interface QSDatabaseQueue ()

--- a/Classes/SQLite/QSDatabaseQueue.m
+++ b/Classes/SQLite/QSDatabaseQueue.m
@@ -7,7 +7,6 @@
 //
 
 #import "FMDatabase.h"
-#import "FMDatabase+Extras.h"
 #import "QSDatabaseQueue.h"
 #import "QSPlatform.h"
 
@@ -48,6 +47,13 @@
 
 #pragma mark - Database
 
+- (FMDatabase*)openDatabaseWithPath:(NSString*)path
+{
+    FMDatabase* db = [FMDatabase databaseWithPath:path];
+    return ([db open]) ? db : nil;
+}
+
+
 - (FMDatabase *)database {
 
 	/*I've always done it this way -- kept a per-thread database in the threadDictionary -- and I know it's solid. Maybe it's not necessary with a serial queue, but my understanding was that SQLite wanted a different database per thread (and a serial queue may run on different threads).*/
@@ -57,7 +63,7 @@
 
 	if (database == nil) {
 
-		database = [FMDatabase openDatabaseWithPath:self.databasePath];
+		database = [self openDatabaseWithPath:self.databasePath];
 		[database executeUpdate:@"PRAGMA synchronous = 1;"];
 		[database setShouldCacheStatements:YES];
 


### PR DESCRIPTION
Ran into a couple of problems while trying to compile QSDatabaseQueue.m in a project that used Xcode 5, ARC, and FMDB 2.1.
1. `QSDatabaseQueue` didn't import `QSPlatform.h` which was generating a compilation error in the `initWithFilename:excludeFromBackup:` method: 
   
   **Implicit conversion of 'int' to 'NSString*' is disallowed with ARC**
2. I couldn't find the `FMDatabase+Extras.h` header file in any recent version of FMDB nor did it seem to be included in QSKit
3. The `FMDatabase` class doesn't seem to declare an `openDatabaseWithPath:` class method. I took a stab at adding it to `QSDatabaseQueue`, though I'll admit that I didn't actually test my implementation. I'm assuming this was likely one of the methods declared in the missing `FMDatabase+Extras.h` header file
