### PR TITLE
excludeFromBackup was never assigned in the initializer but it is used when accessing the database for the first time.

### DIFF
--- a/Classes/SQLite/QSDatabaseQueue.m
+++ b/Classes/SQLite/QSDatabaseQueue.m
@@ -36,10 +36,12 @@
 		NSLog(@"Error creating data folder.");
 		abort();
 	}
-	
+
 	_databasePath = [dataFolder stringByAppendingPathComponent:filename];
 
 	_serialDispatchQueue = dispatch_queue_create([[NSString stringWithFormat:@"QSDatabaseQueue serial queue - %@", filename] UTF8String], DISPATCH_QUEUE_SERIAL);
+
+	_excludeFromBackup = excludeFromBackup;
 
 	return self;
 }


### PR DESCRIPTION
Might be deliberate but figured it didn't hurt to at least raise it :)
