### PR TITLE
Remove redundant check, which causes extra call to [self count]

### DIFF
--- a/Classes/Foundation/NSArray+QSKit.m
+++ b/Classes/Foundation/NSArray+QSKit.m
@@ -14,6 +14,7 @@
 
 - (id)qs_safeObjectAtIndex:(NSUInteger)anIndex {
 	if ([self count] < 1 || anIndex >= [self count])
+	if (anIndex >= [self count])
 		return nil;
 	return [self objectAtIndex:anIndex];
 }


### PR DESCRIPTION
The “anIndex >= [self count]” check already catches all out-of-range
cases, as unsigned numbers cannot be negative.
