### PR TITLE
Delegate the implementation of QSMath to <tgmath.h>

### DIFF
--- a/Classes/QSMath.m
+++ b/Classes/QSMath.m
@@ -7,33 +7,22 @@
 //
 
 #import "QSMath.h"
+#import <tgmath.h>
 
 
 CGFloat QSCeil(CGFloat f) {
 
-	#if __LP64__
-		return ceil(f);
-	#else
-		return ceilf(f);
-	#endif
+	return ceil(f);
 }
 
 CGFloat QSAbs(CGFloat f) {
 
-	#if __LP64__
-		return fabs(f);
-	#else
-		return fabsf(f);
-	#endif
+	return fabs(f);
 }
 
 
 CGFloat QSFloor(CGFloat f) {
 
-	#if __LP64__
-		return floor(f);
-	#else
-		return floorf(f);
-	#endif
+	return floor(f);
 }
 


### PR DESCRIPTION
Thanks for [QSKit](https://github.com/quartermaster/QSKit)! I'm opening this pull request mostly as a question to see if you have any general feedback on `<tgmath.h>`.

[`<tgmath.h>`](http://pubs.opengroup.org/onlinepubs/009696699/basedefs/tgmath.h.html) provides type-generic macros for the functions found in `<math.h>` and `<complex.h>`, so out of the box it handles the branching logic of `QSMath`. If relying on a QS-based interface (e.g., `QSCeil`/`QSAbs`/`QSFloor`) isn't required, clients could directly import `<tgmath.h>` and use its macros.

All [`QSMathTests`](https://github.com/quartermaster/QSKit/blob/7a43cb9eb499035f1c3d9bec70e0b70171e62aa9/QSKitTests/QSMathTests.m) pass.
